### PR TITLE
Upgrade from v1.60.3 to v1.61 and improve upgrade instructions in README.md

### DIFF
--- a/Casks/iguanatexmac.rb
+++ b/Casks/iguanatexmac.rb
@@ -1,6 +1,7 @@
 cask 'iguanatexmac' do
-  version '1.60.3'
-  sha256 '390bad592cc22fb80aabffd519c9753b30025695053048c51d66caf8ef94798a'
+  version '1.61'
+  sha256 'fe46d46778258dc008f1cd011a7c3e117d6b2eeb1dfa18606622e13b285c3efe'
+
 
   url "https://github.com/Jonathan-LeRoux/IguanaTex/releases/download/v#{version}/IguanaTex_v#{version.gsub('.', '_')}.zip"
   name 'IguanaTexMac'

--- a/Casks/latexit-metadata.rb
+++ b/Casks/latexit-metadata.rb
@@ -1,10 +1,10 @@
 cask 'latexit-metadata' do
-  version '1.60.3'
+  version '1.0'
   sha256 '42e23e9ef173de1c716e22a4c842e0a903d543db8b0624d963105e952339d31d'
 
-  url "https://github.com/Jonathan-LeRoux/IguanaTex/releases/download/v#{version}/LaTeXiT-metadata-macos"
+  url "https://github.com/LaTeXiT-metadata/LaTeXiT-metadata-MacOS/releases/download/v#{version}/LaTeXiT-metadata-macos"
   name 'LaTeXiT-metadata'
-  homepage 'https://github.com/Jonathan-LeRoux/IguanaTex'
+  homepage 'https://github.com/LaTeXiT-metadata/LaTeXiT-metadata-MacOS'
 
   artifact "LaTeXiT-metadata-macos",
     target: '/Library/Application Support/Microsoft/Office365/User Content.localized/Add-Ins.localized/LaTeXiT-metadata-macos'

--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ brew install --cask --no-quarantine iguanatexmac latexit-metadata
 
 To upgrade, close PowerPoint, then run:
 ```sh
+brew update
 brew upgrade --cask --no-quarantine iguanatexmac latexit-metadata
 ```
-Check in PowerPoint > Tools > PowerPoint Add-ins that the previous version has been fully removed. If it is still there but disabled, remove it using "-".
+Put your password in if prompted. If PowerPoint starts and shows an error message, click Ok.   
+If PowerPoint started, restart it for changes to take effect. An error message will likely appear complaining that the previous version's `.ppam` file cannot be found, click Ok.   
+In PowerPoint > Tools > PowerPoint Add-ins, if the previous version still appears (it should be disabled), remove it using the "-" button.
 
 To uninstall:
 ```sh

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ brew update
 brew upgrade --cask --no-quarantine iguanatexmac latexit-metadata
 ```
 Put your password in if prompted. If PowerPoint starts and shows an error message, click Ok.   
-If PowerPoint started, restart it for changes to take effect. An error message will likely appear complaining that the previous version's `.ppam` file cannot be found, click Ok.   
-In PowerPoint > Tools > PowerPoint Add-ins, if the previous version still appears (it should be disabled), remove it using the "-" button.
+If PowerPoint did start, restart it for changes to take effect. 
 
 To uninstall:
 ```sh

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ brew tap tsung-ju/iguanatexmac
 brew install --cask --no-quarantine iguanatexmac latexit-metadata
 ```
 
-To upgrade:
+To upgrade, close PowerPoint, then run:
 ```sh
 brew upgrade --cask --no-quarantine iguanatexmac latexit-metadata
 ```
+Check in PowerPoint > Tools > PowerPoint Add-ins that the previous version has been fully removed. If it is still there but disabled, remove it using "-".
 
 To uninstall:
 ```sh


### PR DESCRIPTION
As reported in https://github.com/Jonathan-LeRoux/IguanaTex/issues/58, `brew` upgrade does not automatically remove the previous version from PowerPoint's add-in list, triggering an error when starting PowerPoint.
This PR clarifies the upgrade procedure.